### PR TITLE
Set minimal required permissions

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.json
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.json
@@ -7,16 +7,8 @@
     "rename-desktop-file": "luminance-hdr.desktop",
     "rename-icon": "luminance-hdr",
     "finish-args": [
-        "--share=ipc",
-        "--share=network",
-        "--socket=x11",
-        "--filesystem=host",
-        "--talk-name=org.freedesktop.secrets",
-        /* Needed for dconf to work */
-        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
-        /* Needed for gvfs to work */
-        "--talk-name=org.gtk.vfs", "--talk-name=org.gtk.vfs.*"
+        "--socket=fallback-x11",
+        "--filesystem=home"
     ],
     "modules": [
         {


### PR DESCRIPTION
Replace all those bloated permissions, copy-pasted from Darktable, with two minimal permissions, which are crucial to run the app.